### PR TITLE
Support nested query, has_chlid query

### DIFF
--- a/lib/es-query-builder.rb
+++ b/lib/es-query-builder.rb
@@ -48,12 +48,13 @@ class EsQueryBuilder
   # Returns nothing.
   def initialize(query_fields: [], filter_fields: [],
                  all_query_fields: '_all', hierarchy_fields: [],
-                 nested_fields: {})
+                 nested_fields: {}, child_fields: {})
     @query_fields = query_fields
     @filter_fields = filter_fields
     @all_query_fields = all_query_fields
     @hierarchy_fields = hierarchy_fields
     @nested_fields = nested_fields
+    @child_fields = child_fields
   end
 
   # Public: Convert the given query string into a query object.
@@ -93,6 +94,7 @@ class EsQueryBuilder
     @parser ||= Parser.new(
       all_query_fields: @all_query_fields,
       hierarchy_fields:  @hierarchy_fields,
-      nested_fields: @nested_fields)
+      nested_fields: @nested_fields,
+      child_fields: @child_fields)
   end
 end

--- a/lib/es-query-builder.rb
+++ b/lib/es-query-builder.rb
@@ -47,11 +47,13 @@ class EsQueryBuilder
   #
   # Returns nothing.
   def initialize(query_fields: [], filter_fields: [],
-                 all_query_fields: '_all', hierarchy_fields: [])
+                 all_query_fields: '_all', hierarchy_fields: [],
+                 nested_fields: {})
     @query_fields = query_fields
     @filter_fields = filter_fields
     @all_query_fields = all_query_fields
     @hierarchy_fields = hierarchy_fields
+    @nested_fields = nested_fields
   end
 
   # Public: Convert the given query string into a query object.
@@ -88,6 +90,9 @@ class EsQueryBuilder
   #
   # Returns a Parser.
   def parser
-    @parser ||= Parser.new(@all_query_fields, @hierarchy_fields)
+    @parser ||= Parser.new(
+      all_query_fields: @all_query_fields,
+      hierarchy_fields:  @hierarchy_fields,
+      nested_fields: @nested_fields)
   end
 end

--- a/lib/es-query-builder/parser.rb
+++ b/lib/es-query-builder/parser.rb
@@ -18,9 +18,10 @@ class EsQueryBuilder
     #                    character as a hierarchy (default: []).
     #
     # Returns nothing.
-    def initialize(all_query_fields = '_all', hierarchy_fields = [])
+    def initialize(all_query_fields: '_all', hierarchy_fields: [], nested_fields: {})
       @all_query_fields = all_query_fields
       @hierarchy_fields = hierarchy_fields
+      @nested_fields = nested_fields
     end
 
     # Public: Parse the given tokens and build a query hash.
@@ -155,25 +156,53 @@ class EsQueryBuilder
     def create_bool_queries(query_tokens)
       must, must_not = [], []
       query_tokens.each do |token|
-        # When the field is not given or invalid one, search by all fields.
-        field = token.field || @all_query_fields
         queries = token.minus? ? must_not : must
-        if field.is_a?(String)
-          queries << {
-            match: {
-              field => token.term
-            }
-          }
-        else
-          queries << {
-            multi_match: {
-              fields: field,
-              query: token.term
-            }
-          }
-        end
+
+        queries <<
+          # When the field is not given or invalid one, search by all fields.
+          if token.field.nil?
+            should = []
+            should << create_match_query(@all_query_fields, token.term)
+            @nested_fields.each do |nested_path, nested_field|
+              should << create_nested_match_query(nested_path, nested_field, token.term)
+            end
+            connect_queries(should)
+
+          # When the specify nested field
+          elsif nested_field = @nested_fields[token.field_namespace]
+            create_nested_match_query(token.field_namespace, nested_field, token.term)
+          # When the specify standard field
+          else
+            create_match_query(token.field, token.term)
+          end
       end
       [must, must_not]
+    end
+
+    def create_match_query(field, term)
+      if field.is_a?(String)
+        {
+          match: {
+            field => term
+          }
+        }
+      else
+        {
+          multi_match: {
+            fields: field,
+            query: term
+          }
+        }
+      end
+    end
+
+    def create_nested_match_query(path, field, term)
+      {
+        nested: {
+          path: path.to_s,
+          query: create_match_query(field, term)
+        }
+      }
     end
 
     # Internal: Create boolean filter based on the filter matches.

--- a/lib/es-query-builder/token.rb
+++ b/lib/es-query-builder/token.rb
@@ -1,6 +1,6 @@
 class EsQueryBuilder
   class Token
-    attr_reader :full, :field, :term
+    attr_reader :full, :field, :term, :field_namespace
 
     TYPE_KINDS = %i(query filter or).freeze
 
@@ -10,6 +10,7 @@ class EsQueryBuilder
       @field = field
       @term = term
       @type = type
+      @field_namespace = field.to_s[/^(.+?)\./, 1]
     end
 
     def minus?


### PR DESCRIPTION
I want to keyword search to hit the normal fields and nested fields, child field.
It has not been supported in simple_query_string of ES.
So, I tried to implement the query builder.

``` ruby
builder = EsQueryBuilder.new(nested_fields: { user: ['name', 'profile'] })  
builder.build('hoge')
#=> {:bool=>
#  {:should=>
#    [{:match=>{"_all"=>"hoge"}},
#    {:nested=>{:path=>"user", :query=>{:multi_match=>{:fields=>["name", "profile"], :query=>"hoge"}}}}]}}

builder = EsQueryBuilder.new(child_fields: { entry: ['title', 'body'] })  
builder.build('hoge')
#=> {:bool=>
#  {:should=>
#   [{:match=>{"_all"=>"hoge"}},
#     {:has_child=>{:type=>"entry", :query=>{:multi_match=>{:fields=>["title", "body"], :query=>"hoge"}}}}]}}
```
